### PR TITLE
Add Kotlin multiplatform client skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 ```
 
 客户端实现将基于 `docs/architecture.md` 描述的业务容器、状态管理与导航方案。
+`client/` 目录提供 Kotlin Multiplatform + Compose 的跨端实现，包含业务容器、状态管理、主题/商品/询问/工具/单品等 Tab 视图以及事件网关、LLM 调用的抽象封装。
 
 ## 开发环境
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("com.android.library") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.serialization") apply false
+}

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,0 +1,81 @@
+import org.jetbrains.compose.ExperimentalComposeLibrary
+
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+kotlin {
+    androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val coroutinesVersion = "1.8.1"
+        val serializationVersion = "1.6.3"
+        val datetimeVersion = "0.5.0"
+
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:$datetimeVersion")
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+            }
+        }
+        val androidMain by getting {
+            dependencies {
+                implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+            }
+        }
+        val androidInstrumentedTest by getting
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by creating {
+            dependencies {
+            }
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
+        val iosTest by creating {
+            dependsOn(commonTest)
+            iosX64Test.dependsOn(this)
+            iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
+        }
+    }
+}
+
+android {
+    namespace = "com.sdshop.client"
+    compileSdk = 34
+    defaultConfig {
+        minSdk = 24
+    }
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+compose {
+    @OptIn(ExperimentalComposeLibrary::class)
+    buildFeatures {
+        composeExportDependencies = true
+    }
+}

--- a/client/src/androidMain/AndroidManifest.xml
+++ b/client/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:allowBackup="false" />
+</manifest>

--- a/client/src/commonMain/kotlin/com/sdshop/client/app/AppEnvironment.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/app/AppEnvironment.kt
@@ -1,0 +1,75 @@
+package com.sdshop.client.app
+
+import com.sdshop.client.core.api.LoggingApiGateway
+import com.sdshop.client.core.container.BusinessContainer
+import com.sdshop.client.core.container.BusinessContainerConfig
+import com.sdshop.client.core.event.EventBus
+import com.sdshop.client.core.event.SharedFlowEventBus
+import com.sdshop.client.core.lifecycle.LifecycleCallbacks
+import com.sdshop.client.core.llm.LoggingLlmClient
+import com.sdshop.client.core.state.InMemoryStateStore
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.data.repository.InMemoryThemeRepository
+import com.sdshop.client.data.repository.ThemeRepository
+import com.sdshop.client.feature.inquiry.InquiryController
+import com.sdshop.client.feature.product.ProductListController
+import com.sdshop.client.feature.single.SingleProductController
+import com.sdshop.client.feature.single.SingleProductFlowHandler
+import com.sdshop.client.feature.theme.ThemeFlowHandler
+import com.sdshop.client.feature.theme.ThemeListController
+import com.sdshop.client.feature.tooling.ToolController
+
+class AppEnvironment(
+    val repository: ThemeRepository,
+    val stateStore: StateStore,
+    val container: BusinessContainer,
+    val eventBus: EventBus,
+    val themeController: ThemeListController,
+    val productController: ProductListController,
+    val inquiryController: InquiryController,
+    val toolController: ToolController,
+    val singleProductController: SingleProductController,
+    val navigator: AppNavigator
+)
+
+object AppEnvironmentFactory {
+    fun create(): AppEnvironment {
+        val repository = InMemoryThemeRepository()
+        val stateStore = InMemoryStateStore()
+        val eventBus = SharedFlowEventBus()
+        val llmClient = LoggingLlmClient()
+        val apiGateway = LoggingApiGateway()
+        val themeHandler = ThemeFlowHandler()
+        val singleHandler = SingleProductFlowHandler()
+        val container = BusinessContainer(
+            themeFlowHandler = themeHandler,
+            singleFlowHandler = singleHandler,
+            config = BusinessContainerConfig(
+                repository = repository,
+                stateStore = stateStore,
+                eventBus = eventBus,
+                apiGateway = apiGateway,
+                llmClient = llmClient,
+                lifecycleCallbacks = LifecycleCallbacks()
+            )
+        )
+        val themeController = ThemeListController(repository, stateStore, eventBus)
+        val productController = ProductListController(repository, stateStore, eventBus)
+        val inquiryController = InquiryController(repository, stateStore, llmClient)
+        val toolController = ToolController(repository, stateStore, llmClient)
+        val singleController = SingleProductController(stateStore, llmClient)
+        val navigator = AppNavigator(stateStore)
+        return AppEnvironment(
+            repository = repository,
+            stateStore = stateStore,
+            container = container,
+            eventBus = eventBus,
+            themeController = themeController,
+            productController = productController,
+            inquiryController = inquiryController,
+            toolController = toolController,
+            singleProductController = singleController,
+            navigator = navigator
+        )
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/app/AppNavigator.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/app/AppNavigator.kt
@@ -1,0 +1,13 @@
+package com.sdshop.client.app
+
+import com.sdshop.client.core.state.StateStore
+import kotlinx.coroutines.flow.StateFlow
+
+class AppNavigator(stateStore: StateStore) {
+    private val stateHandle = stateStore.getState(AppScaffoldKey) { AppScaffoldState() }
+    val uiState: StateFlow<AppScaffoldState> = stateHandle.flow
+
+    fun switchTab(tab: AppTab) {
+        stateHandle.update { it.copy(currentTab = tab) }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/app/AppRoot.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/app/AppRoot.kt
@@ -1,0 +1,264 @@
+package com.sdshop.client.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.window.Dialog
+import com.sdshop.client.core.container.FlowRequest
+import com.sdshop.client.core.event.UiEvent
+import com.sdshop.client.data.model.PreferenceTag
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.ProductParameter
+import com.sdshop.client.data.model.ProductPayload
+import com.sdshop.client.data.model.Price
+import com.sdshop.client.data.model.Theme
+import com.sdshop.client.data.model.ThemePreference
+import com.sdshop.client.feature.detail.ProductDetailScreen
+import com.sdshop.client.feature.inquiry.InquiryRoute
+import com.sdshop.client.feature.product.ProductListRoute
+import com.sdshop.client.feature.single.SingleProductRoute
+import com.sdshop.client.feature.theme.ThemeListRoute
+import com.sdshop.client.feature.tooling.ToolRoute
+import kotlinx.coroutines.flow.collect
+import kotlinx.datetime.Clock
+import kotlin.random.Random
+import kotlin.uuid.Uuid
+
+@Composable
+fun AppRoot(environment: AppEnvironment) {
+    LaunchedEffect(environment) {
+        environment.container.start(FlowRequest.ThemeFlow())
+    }
+    val scaffoldState by environment.navigator.uiState.collectAsState()
+    var themeDialogState by remember { mutableStateOf<ThemeDialogState?>(null) }
+    var showProductDialog by remember { mutableStateOf(false) }
+    var detailProduct by remember { mutableStateOf<Product?>(null) }
+    var singleProduct by remember { mutableStateOf<Product?>(null) }
+
+    LaunchedEffect(environment.eventBus) {
+        environment.eventBus.observe(UiEvent.LaunchSingleProduct::class.java).collect { event ->
+            val product = environment.productController.uiState.value.products
+                .firstOrNull { it.product.id == event.productId }?.product
+            product?.let { openSingleProduct(environment, it) { opened -> singleProduct = opened } }
+        }
+    }
+
+    detailProduct?.let { product ->
+        Dialog(onDismissRequest = { detailProduct = null }) {
+            Surface {
+                ProductDetailScreen(
+                    product = product,
+                    onOpenSingle = {
+                        openSingleProduct(environment, product) { opened -> singleProduct = opened }
+                        detailProduct = null
+                    },
+                    onAddToTheme = {
+                        environment.productController.addProduct(product)
+                        detailProduct = null
+                    }
+                )
+            }
+        }
+    }
+
+    singleProduct?.let {
+        Dialog(onDismissRequest = { singleProduct = null }) {
+            Surface(modifier = Modifier.fillMaxSize()) {
+                SingleProductRoute(
+                    controller = environment.singleProductController,
+                    onUpgrade = { product ->
+                        singleProduct = null
+                        themeDialogState = ThemeDialogState.Create(defaultTitle = product.title)
+                    }
+                )
+            }
+        }
+    }
+
+    themeDialogState?.let { dialogState ->
+        ThemeDialog(
+            state = dialogState,
+            onDismiss = { themeDialogState = null },
+            onConfirm = { title, preference ->
+                when (dialogState) {
+                    is ThemeDialogState.Create -> environment.themeController.createTheme(title, preference)
+                    is ThemeDialogState.Edit -> environment.themeController.updateTheme(dialogState.theme.copy(title = title, preference = preference))
+                }
+                themeDialogState = null
+            }
+        )
+    }
+
+    if (showProductDialog) {
+        ProductDialog(
+            onDismiss = { showProductDialog = false },
+            onConfirm = { product ->
+                environment.productController.addProduct(product)
+                showProductDialog = false
+            }
+        )
+    }
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                AppTab.values().forEach { tab ->
+                    NavigationBarItem(
+                        selected = scaffoldState.currentTab == tab,
+                        onClick = { environment.navigator.switchTab(tab) },
+                        label = { Text(tab.name) },
+                        icon = {}
+                    )
+                }
+            }
+        }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (scaffoldState.currentTab) {
+                AppTab.THEMES -> ThemeListRoute(
+                    controller = environment.themeController,
+                    onCreateTheme = { themeDialogState = ThemeDialogState.Create() },
+                    onEditTheme = { theme -> themeDialogState = ThemeDialogState.Edit(theme) },
+                    onImportToTheme = { theme -> environment.themeController.importPendingToTheme(theme.id) }
+                )
+                AppTab.PRODUCTS -> ProductListRoute(
+                    controller = environment.productController,
+                    onAddProduct = { showProductDialog = true },
+                    onOpenDetail = { product -> detailProduct = product }
+                )
+                AppTab.INQUIRY -> InquiryRoute(environment.inquiryController)
+                AppTab.TOOLS -> ToolRoute(environment.toolController)
+            }
+        }
+    }
+}
+
+private fun openSingleProduct(environment: AppEnvironment, product: Product, onOpened: (Product) -> Unit) {
+    environment.container.start(FlowRequest.SingleProductFlow(ProductPayload.Single(product)))
+    onOpened(product)
+}
+
+private sealed interface ThemeDialogState {
+    data class Create(val defaultTitle: String = "") : ThemeDialogState
+    data class Edit(val theme: Theme) : ThemeDialogState
+}
+
+@Composable
+private fun ThemeDialog(
+    state: ThemeDialogState,
+    onDismiss: () -> Unit,
+    onConfirm: (String, ThemePreference) -> Unit
+) {
+    val initialTheme = (state as? ThemeDialogState.Edit)?.theme
+    var title by remember { mutableStateOf(initialTheme?.title ?: (state as? ThemeDialogState.Create)?.defaultTitle.orEmpty()) }
+    var freeText by remember { mutableStateOf(initialTheme?.preference?.freeText ?: "") }
+    var selectedTags by remember { mutableStateOf(initialTheme?.preference?.tags ?: emptyList()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (initialTheme == null) "创建主题" else "编辑主题") },
+        text = {
+            Column {
+                androidx.compose.material3.TextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    label = { Text("主题名称") }
+                )
+                androidx.compose.material3.TextField(
+                    value = freeText,
+                    onValueChange = { freeText = it },
+                    label = { Text("偏好描述") }
+                )
+                PreferenceTagSelector(selectedTags) { tag ->
+                    selectedTags = if (selectedTags.contains(tag)) {
+                        selectedTags - tag
+                    } else {
+                        selectedTags + tag
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(title, ThemePreference(selectedTags, freeText)) }) { Text("保存") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("取消") }
+        }
+    )
+}
+
+@Composable
+private fun PreferenceTagSelector(
+    selected: List<PreferenceTag>,
+    onToggle: (PreferenceTag) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("预设偏好", fontWeight = FontWeight.Bold)
+        PreferenceTag.values().forEach { tag ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(checked = selected.contains(tag), onCheckedChange = { onToggle(tag) })
+                Text(tag.displayName, modifier = Modifier.padding(start = 8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (Product) -> Unit
+) {
+    var title by remember { mutableStateOf("") }
+    var priceText by remember { mutableStateOf("999.0") }
+    var description by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("添加商品") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                androidx.compose.material3.TextField(value = title, onValueChange = { title = it }, label = { Text("商品标题") })
+                androidx.compose.material3.TextField(value = priceText, onValueChange = { priceText = it }, label = { Text("价格") })
+                androidx.compose.material3.TextField(value = description, onValueChange = { description = it }, label = { Text("描述") })
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val product = Product(
+                    id = Uuid.random().toString(),
+                    heroImages = emptyList(),
+                    title = title.ifBlank { "商品${Random.nextInt(100)}" },
+                    price = Price(priceText.toDoubleOrNull() ?: 0.0),
+                    description = description,
+                    parameters = listOf(ProductParameter("创建时间", Clock.System.now().toString()))
+                )
+                onConfirm(product)
+            }) { Text("添加") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/app/AppState.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/app/AppState.kt
@@ -1,0 +1,65 @@
+package com.sdshop.client.app
+
+import com.sdshop.client.core.state.StateKey
+import com.sdshop.client.data.model.InquiryRecord
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.Theme
+import com.sdshop.client.data.model.ThemeProduct
+import com.sdshop.client.data.model.ToolDefinition
+import com.sdshop.client.data.model.ToolRecord
+
+enum class AppTab { THEMES, PRODUCTS, INQUIRY, TOOLS }
+
+data class ThemeListUiState(
+    val items: List<Theme> = emptyList(),
+    val selectedThemeId: String? = null,
+    val isLoading: Boolean = false,
+    val page: Int = 0,
+    val endReached: Boolean = false,
+    val pendingImport: List<Product> = emptyList()
+) {
+    val isEmpty: Boolean get() = items.isEmpty()
+}
+
+object ThemeListKey : StateKey<ThemeListUiState>
+
+data class ProductListUiState(
+    val themeId: String? = null,
+    val products: List<ThemeProduct> = emptyList(),
+    val isLoading: Boolean = false
+)
+
+object ProductListKey : StateKey<ProductListUiState>
+
+data class InquiryUiState(
+    val themeId: String? = null,
+    val records: List<InquiryRecord> = emptyList(),
+    val draft: String = "",
+    val isLoading: Boolean = false
+)
+
+object InquiryKey : StateKey<InquiryUiState>
+
+data class ToolUiState(
+    val themeId: String? = null,
+    val tools: List<ToolDefinition> = emptyList(),
+    val records: List<ToolRecord> = emptyList(),
+    val isLoading: Boolean = false
+)
+
+object ToolKey : StateKey<ToolUiState>
+
+data class SingleProductUiState(
+    val product: Product? = null,
+    val inquiries: List<InquiryRecord> = emptyList(),
+    val toolRecords: List<ToolRecord> = emptyList(),
+    val isLoading: Boolean = false
+)
+
+object SingleProductKey : StateKey<SingleProductUiState>
+
+data class AppScaffoldState(
+    val currentTab: AppTab = AppTab.THEMES
+)
+
+object AppScaffoldKey : StateKey<AppScaffoldState>

--- a/client/src/commonMain/kotlin/com/sdshop/client/core/api/ApiGateway.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/core/api/ApiGateway.kt
@@ -1,0 +1,30 @@
+package com.sdshop.client.core.api
+
+import kotlinx.coroutines.delay
+
+sealed interface ApiResult<out T> {
+    data class Success<T>(val value: T) : ApiResult<T>
+    data class Error(val throwable: Throwable) : ApiResult<Nothing>
+}
+
+data class ApiRequest(
+    val path: String,
+    val payload: Any? = null,
+    val method: HttpMethod = HttpMethod.GET
+)
+
+enum class HttpMethod { GET, POST, PUT, DELETE }
+
+interface ApiGateway {
+    suspend fun <T> execute(request: ApiRequest, handler: suspend (ApiRequest) -> T): ApiResult<T>
+}
+
+class LoggingApiGateway : ApiGateway {
+    override suspend fun <T> execute(request: ApiRequest, handler: suspend (ApiRequest) -> T): ApiResult<T> =
+        try {
+            delay(50)
+            ApiResult.Success(handler(request))
+        } catch (t: Throwable) {
+            ApiResult.Error(t)
+        }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/core/container/BusinessContainer.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/core/container/BusinessContainer.kt
@@ -1,0 +1,84 @@
+package com.sdshop.client.core.container
+
+import com.sdshop.client.core.api.ApiGateway
+import com.sdshop.client.core.event.EventBus
+import com.sdshop.client.core.lifecycle.LifecycleCallbacks
+import com.sdshop.client.core.lifecycle.LifecycleRegistry
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.core.llm.LlmClient
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.ProductPayload
+import com.sdshop.client.data.repository.ThemeRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+sealed interface FlowRequest {
+    data class ThemeFlow(
+        val themeId: String? = null,
+        val importedProducts: List<Product> = emptyList()
+    ) : FlowRequest
+
+    data class SingleProductFlow(
+        val payload: ProductPayload
+    ) : FlowRequest
+}
+
+data class BusinessContainerConfig(
+    val repository: ThemeRepository,
+    val stateStore: StateStore,
+    val eventBus: EventBus,
+    val apiGateway: ApiGateway,
+    val llmClient: LlmClient,
+    val lifecycleCallbacks: LifecycleCallbacks = LifecycleCallbacks(),
+    val coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+)
+
+data class FlowContext(
+    val request: FlowRequest,
+    val repository: ThemeRepository,
+    val stateStore: StateStore,
+    val eventBus: EventBus,
+    val apiGateway: ApiGateway,
+    val llmClient: LlmClient,
+    val lifecycle: LifecycleRegistry
+)
+
+fun interface FlowHandler<R : FlowRequest> {
+    suspend fun FlowContext.handle(request: R)
+}
+
+class BusinessContainer(
+    private val themeFlowHandler: FlowHandler<FlowRequest.ThemeFlow>,
+    private val singleFlowHandler: FlowHandler<FlowRequest.SingleProductFlow>,
+    private val config: BusinessContainerConfig
+) {
+    private val lifecycle = LifecycleRegistry(config.coroutineContext)
+    private val scope = CoroutineScope(config.coroutineContext)
+
+    fun start(request: FlowRequest) {
+        scope.launch {
+            val flowContext = FlowContext(
+                request = request,
+                repository = config.repository,
+                stateStore = config.stateStore,
+                eventBus = config.eventBus,
+                apiGateway = config.apiGateway,
+                llmClient = config.llmClient,
+                lifecycle = lifecycle
+            )
+            lifecycle.run(config.lifecycleCallbacks) {
+                when (request) {
+                    is FlowRequest.ThemeFlow -> themeFlowHandler.run { with(flowContext) { handle(request) } }
+                    is FlowRequest.SingleProductFlow -> singleFlowHandler.run { with(flowContext) { handle(request) } }
+                }
+            }
+        }
+    }
+
+    fun dispose() {
+        lifecycle.cancel()
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/core/event/EventBus.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/core/event/EventBus.kt
@@ -1,0 +1,36 @@
+package com.sdshop.client.core.event
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+interface EventBus {
+    fun publish(event: UiEvent)
+    fun <T : UiEvent> observe(clazz: Class<T>): Flow<T>
+}
+
+sealed interface UiEvent {
+    data object RefreshThemes : UiEvent
+    data class ThemeSelected(val themeId: String) : UiEvent
+    data class ShowSnackbar(val message: String) : UiEvent
+    data class LaunchSingleProduct(val productId: String) : UiEvent
+}
+
+class SharedFlowEventBus(
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) : EventBus {
+    private val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 32)
+    private val scope = CoroutineScope(coroutineContext)
+
+    override fun publish(event: UiEvent) {
+        scope.launch { events.emit(event) }
+    }
+
+    override fun <T : UiEvent> observe(clazz: Class<T>): Flow<T> =
+        events.filterIsInstance(clazz.kotlin)
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/core/lifecycle/Lifecycle.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/core/lifecycle/Lifecycle.kt
@@ -1,0 +1,49 @@
+package com.sdshop.client.core.lifecycle
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
+
+data class LifecycleCallbacks(
+    val onInit: suspend LifecycleScope.() -> Unit = {},
+    val beforeRequest: suspend LifecycleScope.() -> Unit = {},
+    val afterRequest: suspend LifecycleScope.() -> Unit = {},
+    val onData: suspend LifecycleScope.() -> Unit = {},
+    val onComplete: suspend LifecycleScope.() -> Unit = {},
+    val onError: suspend LifecycleScope.(Throwable) -> Unit = {}
+)
+
+class LifecycleScope(
+    val coroutineScope: CoroutineScope,
+    private val setLoading: (Boolean) -> Unit
+) {
+    fun markLoading(isLoading: Boolean) = setLoading(isLoading)
+}
+
+class LifecycleRegistry(
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) {
+    private val job = Job()
+    val scope: CoroutineScope = CoroutineScope(coroutineContext + job)
+
+    suspend fun run(callbacks: LifecycleCallbacks, block: suspend LifecycleScope.() -> Unit) {
+        val lifecycleScope = LifecycleScope(scope) {}
+        try {
+            callbacks.onInit.invoke(lifecycleScope)
+            callbacks.beforeRequest.invoke(lifecycleScope)
+            lifecycleScope.block()
+            callbacks.afterRequest.invoke(lifecycleScope)
+            callbacks.onData.invoke(lifecycleScope)
+            callbacks.onComplete.invoke(lifecycleScope)
+        } catch (t: Throwable) {
+            callbacks.onError.invoke(lifecycleScope, t)
+            throw t
+        }
+    }
+
+    fun cancel() {
+        job.cancel()
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/core/llm/LlmClient.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/core/llm/LlmClient.kt
@@ -1,0 +1,68 @@
+package com.sdshop.client.core.llm
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flow
+
+enum class LlmProvider {
+    CHAT_GPT, GEMINI, QWEN
+}
+
+data class LlmPrompt(
+    val system: String,
+    val user: String,
+    val context: Map<String, Any?> = emptyMap()
+)
+
+data class LlmDelta(
+    val content: String,
+    val isFinal: Boolean
+)
+
+data class LlmRequest(
+    val provider: LlmProvider,
+    val prompt: LlmPrompt
+)
+
+interface LlmClient {
+    fun stream(request: LlmRequest): Flow<LlmDelta>
+    suspend fun complete(request: LlmRequest): String
+    val events: Flow<LlmEvent>
+}
+
+sealed interface LlmEvent {
+    data class RequestStarted(val request: LlmRequest) : LlmEvent
+    data class RequestCompleted(val request: LlmRequest, val response: String) : LlmEvent
+    data class RequestFailed(val request: LlmRequest, val throwable: Throwable) : LlmEvent
+}
+
+class LoggingLlmClient : LlmClient {
+    private val eventFlow = MutableSharedFlow<LlmEvent>(extraBufferCapacity = 16)
+
+    override val events: Flow<LlmEvent> = eventFlow.asSharedFlow()
+
+    override fun stream(request: LlmRequest): Flow<LlmDelta> = flow {
+        eventFlow.tryEmit(LlmEvent.RequestStarted(request))
+        val content = buildString {
+            append("[${request.provider}] ")
+            append(request.prompt.system)
+            append("\n---\n")
+            append(request.prompt.user)
+            if (request.prompt.context.isNotEmpty()) {
+                append("\ncontext=")
+                append(request.prompt.context)
+            }
+        }
+        emit(LlmDelta(content = content, isFinal = true))
+        eventFlow.tryEmit(LlmEvent.RequestCompleted(request, content))
+    }
+
+    override suspend fun complete(request: LlmRequest): String {
+        var response = ""
+        stream(request).collect { delta ->
+            response += delta.content
+        }
+        return response
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/core/state/StateStore.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/core/state/StateStore.kt
@@ -1,0 +1,48 @@
+package com.sdshop.client.core.state
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+interface StateKey<T : Any>
+
+interface StateStore {
+    fun <T : Any> getState(key: StateKey<T>, default: () -> T): StateHandle<T>
+}
+
+interface StateHandle<T : Any> {
+    val flow: StateFlow<T>
+    fun update(transform: (T) -> T)
+    fun set(value: T) = update { value }
+}
+
+class MutableStateHandle<T : Any>(
+    private val scope: CoroutineScope,
+    private val stateFlow: MutableStateFlow<T>
+) : StateHandle<T> {
+    override val flow: StateFlow<T> = stateFlow.asStateFlow()
+
+    override fun update(transform: (T) -> T) {
+        scope.launch { stateFlow.value = transform(stateFlow.value) }
+    }
+}
+
+class InMemoryStateStore(
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) : StateStore {
+    private val scope = CoroutineScope(coroutineContext)
+    private val state = mutableMapOf<StateKey<*>, MutableStateFlow<out Any>>()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> getState(key: StateKey<T>, default: () -> T): StateHandle<T> {
+        val flow = state.getOrPut(key) {
+            MutableStateFlow(default())
+        } as MutableStateFlow<T>
+        return MutableStateHandle(scope, flow)
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/data/model/ProductModels.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/data/model/ProductModels.kt
@@ -1,0 +1,94 @@
+package com.sdshop.client.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Price(
+    val amount: Double,
+    val currency: String = "CNY"
+) {
+    val formatted: String get() = if (currency.isBlank()) amount.toString() else "$currency ${"%.2f".format(amount)}"
+}
+
+@Serializable
+data class ProductParameter(
+    val name: String,
+    val value: String
+)
+
+@Serializable
+data class LogisticsInfo(
+    val deliveryTime: String,
+    val freightPolicy: String,
+    val supportRegions: List<String>
+)
+
+@Serializable
+data class AfterSalePolicy(
+    val warranty: String,
+    val returnPolicy: String,
+    val serviceChannels: List<String>
+)
+
+@Serializable
+data class ReviewSummary(
+    val score: Double,
+    val reviewCount: Int,
+    val highlights: List<String>
+)
+
+@Serializable
+data class ProductQuestion(
+    val question: String,
+    val answer: String,
+    val upVotes: Int = 0
+)
+
+@Serializable
+data class ShopInfo(
+    val name: String,
+    val rating: Double,
+    val badges: List<String>
+)
+
+@Serializable
+data class Product(
+    val id: String,
+    val heroImages: List<String>,
+    val title: String,
+    val price: Price,
+    val parameters: List<ProductParameter> = emptyList(),
+    val logistics: LogisticsInfo? = null,
+    val rankings: List<String> = emptyList(),
+    val afterSale: AfterSalePolicy? = null,
+    val reviews: ReviewSummary? = null,
+    val questions: List<ProductQuestion> = emptyList(),
+    val shop: ShopInfo? = null,
+    val description: String = ""
+)
+
+@Serializable
+data class ProductTag(
+    val id: String,
+    val label: String
+)
+
+@Serializable
+data class ThemeProduct(
+    val product: Product,
+    val tags: List<ProductTag> = emptyList(),
+    val addedAtMillis: Long
+)
+
+@Serializable
+sealed interface ProductPayload {
+    val product: Product
+
+    @Serializable
+    data class Single(override val product: Product) : ProductPayload
+
+    @Serializable
+    data class Multiple(val items: List<Product>) : ProductPayload {
+        override val product: Product get() = items.first()
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/data/model/SingleModels.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/data/model/SingleModels.kt
@@ -1,0 +1,12 @@
+package com.sdshop.client.data.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SingleProductSession(
+    val product: Product,
+    val inquiries: List<InquiryRecord> = emptyList(),
+    val toolRecords: List<ToolRecord> = emptyList(),
+    val lastUpdated: Instant = Instant.DISTANT_PAST
+)

--- a/client/src/commonMain/kotlin/com/sdshop/client/data/model/ThemeModels.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/data/model/ThemeModels.kt
@@ -1,0 +1,75 @@
+package com.sdshop.client.data.model
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class PreferenceTag(val displayName: String) {
+    VALUE("追求性价比"),
+    NEW_RELEASES("关注最新款"),
+    BRAND("注重品牌"),
+    ECO("环保材质优先");
+
+    companion object {
+        val defaults = values().toList()
+    }
+}
+
+@Serializable
+data class ThemePreference(
+    val tags: List<PreferenceTag> = emptyList(),
+    val freeText: String = ""
+)
+
+@Serializable
+data class Theme(
+    val id: String,
+    val title: String,
+    val preference: ThemePreference = ThemePreference(),
+    val products: List<ThemeProduct> = emptyList(),
+    val inquiries: List<InquiryRecord> = emptyList(),
+    val toolRecords: List<ToolRecord> = emptyList(),
+    val createdAt: Instant = Clock.System.now(),
+    val updatedAt: Instant = createdAt
+)
+
+@Serializable
+data class InquiryRecord(
+    val id: String,
+    val question: String,
+    val answer: String,
+    val timestamp: Instant,
+    val relatedProductIds: List<String> = emptyList()
+)
+
+@Serializable
+data class ToolRecord(
+    val id: String,
+    val tool: ToolDefinition,
+    val output: String,
+    val timestamp: Instant
+)
+
+@Serializable
+data class ToolDefinition(
+    val id: String,
+    val name: String,
+    val description: String,
+    val systemPrompt: String,
+    val capabilities: List<String> = emptyList()
+)
+
+@Serializable
+data class ThemeSummary(
+    val theme: Theme,
+    val highlight: String,
+    val productSummaries: List<ProductSummary>
+)
+
+@Serializable
+data class ProductSummary(
+    val productId: String,
+    val tags: List<String>,
+    val summary: String
+)

--- a/client/src/commonMain/kotlin/com/sdshop/client/data/repository/SingleProductRepository.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/data/repository/SingleProductRepository.kt
@@ -1,0 +1,25 @@
+package com.sdshop.client.data.repository
+
+import com.sdshop.client.data.model.SingleProductSession
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+interface SingleProductRepository {
+    val sessions: Flow<List<SingleProductSession>>
+    suspend fun upsert(session: SingleProductSession): SingleProductSession
+    suspend fun get(productId: String): SingleProductSession?
+}
+
+class InMemorySingleProductRepository : SingleProductRepository {
+    private val state = MutableStateFlow<List<SingleProductSession>>(emptyList())
+
+    override val sessions: Flow<List<SingleProductSession>> = state
+
+    override suspend fun upsert(session: SingleProductSession): SingleProductSession {
+        state.value = state.value.filterNot { it.product.id == session.product.id } + session
+        return session
+    }
+
+    override suspend fun get(productId: String): SingleProductSession? =
+        state.value.firstOrNull { it.product.id == productId }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/data/repository/ThemeRepository.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/data/repository/ThemeRepository.kt
@@ -1,0 +1,93 @@
+package com.sdshop.client.data.repository
+
+import com.sdshop.client.data.model.InquiryRecord
+import com.sdshop.client.data.model.Theme
+import com.sdshop.client.data.model.ThemeProduct
+import com.sdshop.client.data.model.ToolRecord
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Clock
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+interface ThemeRepository {
+    val themes: Flow<List<Theme>>
+    suspend fun upsert(theme: Theme): Theme
+    suspend fun delete(themeId: String)
+    suspend fun get(themeId: String): Theme?
+    suspend fun addProducts(themeId: String, products: List<ThemeProduct>): Theme
+    suspend fun removeProduct(themeId: String, productId: String): Theme
+    suspend fun appendInquiry(themeId: String, record: InquiryRecord): Theme
+    suspend fun appendToolRecord(themeId: String, record: ToolRecord): Theme
+}
+
+@OptIn(ExperimentalUuidApi::class)
+class InMemoryThemeRepository : ThemeRepository {
+    private val state = MutableStateFlow<List<Theme>>(emptyList())
+
+    override val themes: Flow<List<Theme>> = state.map { themes ->
+        themes.sortedByDescending { it.updatedAt }
+    }
+
+    override suspend fun upsert(theme: Theme): Theme {
+        val updated = theme.copy(updatedAt = Clock.System.now())
+        state.value = state.value
+            .filterNot { it.id == theme.id }
+            .plus(updated)
+        return updated
+    }
+
+    override suspend fun delete(themeId: String) {
+        state.value = state.value.filterNot { it.id == themeId }
+    }
+
+    override suspend fun get(themeId: String): Theme? = state.value.firstOrNull { it.id == themeId }
+
+    override suspend fun addProducts(themeId: String, products: List<ThemeProduct>): Theme {
+        return updateTheme(themeId) { theme ->
+            val merged = theme.products.toMutableList()
+            products.forEach { product ->
+                merged.removeAll { it.product.id == product.product.id }
+                merged.add(product)
+            }
+            theme.copy(products = merged.sortedByDescending { it.addedAtMillis })
+        }
+    }
+
+    override suspend fun removeProduct(themeId: String, productId: String): Theme =
+        updateTheme(themeId) { theme ->
+            theme.copy(products = theme.products.filterNot { it.product.id == productId })
+        }
+
+    override suspend fun appendInquiry(themeId: String, record: InquiryRecord): Theme =
+        updateTheme(themeId) { theme ->
+            theme.copy(inquiries = theme.inquiries + record)
+        }
+
+    override suspend fun appendToolRecord(themeId: String, record: ToolRecord): Theme =
+        updateTheme(themeId) { theme ->
+            theme.copy(toolRecords = theme.toolRecords + record)
+        }
+
+    private suspend fun updateTheme(themeId: String, transform: (Theme) -> Theme): Theme {
+        val target = state.value.firstOrNull { it.id == themeId }
+            ?: throw IllegalArgumentException("Theme $themeId not found")
+        val updated = transform(target).copy(updatedAt = Clock.System.now())
+        state.value = state.value.map { if (it.id == themeId) updated else it }
+        return updated
+    }
+
+    companion object {
+        fun newTheme(
+            title: String,
+            preference: com.sdshop.client.data.model.ThemePreference
+        ): Theme = Theme(
+            id = Uuid.random().toString(),
+            title = title,
+            preference = preference,
+            createdAt = Clock.System.now(),
+            updatedAt = Clock.System.now()
+        )
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/detail/ProductDetailScreen.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/detail/ProductDetailScreen.kt
@@ -1,0 +1,126 @@
+package com.sdshop.client.feature.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.ProductParameter
+
+@Composable
+fun ProductDetailScreen(
+    product: Product,
+    onOpenSingle: () -> Unit,
+    onAddToTheme: () -> Unit
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier.weight(1f).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                item {
+                    Text(product.title, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                    Spacer(Modifier.height(8.dp))
+                    Text(product.price.formatted, style = MaterialTheme.typography.titleLarge)
+                }
+                if (product.parameters.isNotEmpty()) {
+                    item { SectionTitle("核心参数") }
+                    items(product.parameters) { parameter ->
+                        ParameterRow(parameter)
+                    }
+                }
+                if (product.description.isNotBlank()) {
+                    item {
+                        SectionTitle("商品详情")
+                        Text(product.description, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+                product.shop?.let { shop ->
+                    item {
+                        SectionTitle("店铺")
+                        Text(shop.name, style = MaterialTheme.typography.titleMedium)
+                        Text("评分 ${shop.rating}", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+                product.reviews?.let { reviews ->
+                    item {
+                        SectionTitle("评价概览")
+                        Text("评分 ${reviews.score}（${reviews.reviewCount} 条）", style = MaterialTheme.typography.bodyMedium)
+                        if (reviews.highlights.isNotEmpty()) {
+                            Spacer(Modifier.height(8.dp))
+                            reviews.highlights.forEach { highlight ->
+                                Text("• $highlight", style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    }
+                }
+                if (product.rankings.isNotEmpty()) {
+                    item {
+                        SectionTitle("榜单")
+                        product.rankings.forEach { rank -> Text(rank, style = MaterialTheme.typography.bodySmall) }
+                    }
+                }
+                product.logistics?.let { logistics ->
+                    item {
+                        SectionTitle("物流")
+                        Text("送达时间：${logistics.deliveryTime}", style = MaterialTheme.typography.bodySmall)
+                        Text("包邮政策：${logistics.freightPolicy}", style = MaterialTheme.typography.bodySmall)
+                        Spacer(Modifier.height(4.dp))
+                        logistics.supportRegions.takeIf { it.isNotEmpty() }?.let { regions ->
+                            Text("支持地区：${regions.joinToString()}", style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+                product.afterSale?.let { afterSale ->
+                    item {
+                        SectionTitle("售后")
+                        Text("质保：${afterSale.warranty}", style = MaterialTheme.typography.bodySmall)
+                        Text("退换：${afterSale.returnPolicy}", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            }
+            Divider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(modifier = Modifier.weight(1f), onClick = onOpenSingle) { Text("单品询问") }
+                Button(modifier = Modifier.weight(1f), onClick = onAddToTheme) { Text("加入主题") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(title: String) {
+    Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+}
+
+@Composable
+private fun ParameterRow(parameter: ProductParameter) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(parameter.name, style = MaterialTheme.typography.bodyMedium)
+        Text(parameter.value, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/inquiry/InquiryController.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/inquiry/InquiryController.kt
@@ -1,0 +1,111 @@
+package com.sdshop.client.feature.inquiry
+
+import com.sdshop.client.app.InquiryKey
+import com.sdshop.client.app.InquiryUiState
+import com.sdshop.client.core.llm.LlmClient
+import com.sdshop.client.core.llm.LlmPrompt
+import com.sdshop.client.core.llm.LlmProvider
+import com.sdshop.client.core.llm.LlmRequest
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.data.model.InquiryRecord
+import com.sdshop.client.data.repository.ThemeRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.coroutines.CoroutineContext
+import kotlin.uuid.Uuid
+
+class InquiryController(
+    private val repository: ThemeRepository,
+    private val stateStore: StateStore,
+    private val llmClient: LlmClient,
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) {
+    private val scope = CoroutineScope(coroutineContext)
+    private val state = stateStore.getState(InquiryKey) { InquiryUiState() }
+
+    val uiState: StateFlow<InquiryUiState> = state.flow
+
+    init {
+        scope.launch {
+            uiState.collect { ui ->
+                val themeId = ui.themeId ?: return@collect
+                if (ui.records.isEmpty() && !ui.isLoading) {
+                    generateSummary(themeId)
+                }
+            }
+        }
+    }
+
+    fun updateDraft(text: String) {
+        state.update { it.copy(draft = text) }
+    }
+
+    fun send(text: String? = null) {
+        val input = text ?: state.flow.value.draft
+        val themeId = state.flow.value.themeId ?: return
+        if (input.isBlank()) return
+        scope.launch {
+            state.update { it.copy(isLoading = true, draft = "") }
+            val theme = repository.get(themeId) ?: return@launch
+            val prompt = LlmPrompt(
+                system = "你是用户的购物助理，根据主题和偏好回答。",
+                user = input,
+                context = mapOf(
+                    "theme" to theme.title,
+                    "preference" to theme.preference,
+                    "products" to theme.products
+                )
+            )
+            val response = llmClient.complete(LlmRequest(provider = LlmProvider.CHAT_GPT, prompt = prompt))
+            val record = InquiryRecord(
+                id = Uuid.random().toString(),
+                question = input,
+                answer = response,
+                timestamp = Clock.System.now(),
+                relatedProductIds = theme.products.map { it.product.id }
+            )
+            repository.appendInquiry(themeId, record)
+            state.update {
+                it.copy(
+                    isLoading = false,
+                    records = it.records + record
+                )
+            }
+        }
+    }
+
+    fun generateSummary(themeId: String? = state.flow.value.themeId) {
+        val targetId = themeId ?: return
+        scope.launch {
+            state.update { it.copy(isLoading = true) }
+            val theme = repository.get(targetId) ?: return@launch
+            val prompt = LlmPrompt(
+                system = "你是一个擅长做多商品调研总结的专家，输出结构化分类总结。",
+                user = "请根据主题《${theme.title}》、偏好${theme.preference}和商品列表，生成分类总结。",
+                context = mapOf(
+                    "products" to theme.products,
+                    "preference" to theme.preference
+                )
+            )
+            val summary = llmClient.complete(LlmRequest(provider = LlmProvider.CHAT_GPT, prompt = prompt))
+            val record = InquiryRecord(
+                id = Uuid.random().toString(),
+                question = "系统总结",
+                answer = summary,
+                timestamp = Clock.System.now(),
+                relatedProductIds = theme.products.map { it.product.id }
+            )
+            repository.appendInquiry(targetId, record)
+            state.update {
+                it.copy(
+                    isLoading = false,
+                    records = it.records + record
+                )
+            }
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/inquiry/InquiryScreens.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/inquiry/InquiryScreens.kt
@@ -1,0 +1,104 @@
+package com.sdshop.client.feature.inquiry
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.sdshop.client.app.InquiryUiState
+import com.sdshop.client.data.model.InquiryRecord
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+fun InquiryRoute(
+    controller: InquiryController
+) {
+    val state by controller.uiState.collectAsState()
+    InquiryScreen(
+        state = state,
+        onSend = controller::send,
+        onDraftChanged = controller::updateDraft,
+        onGenerateSummary = controller::generateSummary
+    )
+}
+
+@Composable
+fun InquiryScreen(
+    state: InquiryUiState,
+    onSend: (String) -> Unit,
+    onDraftChanged: (String) -> Unit,
+    onGenerateSummary: () -> Unit
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("询问助手", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Button(onClick = onGenerateSummary) { Text("生成总结") }
+            }
+            Spacer(Modifier.height(16.dp))
+            LazyColumn(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                items(state.records) { record ->
+                    InquiryBubble(record)
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = state.draft,
+                onValueChange = onDraftChanged,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("输入你的问题或语音转写") },
+                singleLine = false
+            )
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = { onSend(state.draft) }, enabled = state.draft.isNotBlank() && !state.isLoading) {
+                    Text("发送文本")
+                }
+                Button(onClick = { onSend("语音提问：" + state.draft) }, enabled = state.draft.isNotBlank() && !state.isLoading) {
+                    Text("语音发送")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InquiryBubble(record: InquiryRecord) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(12.dp)
+    ) {
+        Text("Q: ${record.question}", style = MaterialTheme.typography.titleSmall)
+        Spacer(Modifier.height(4.dp))
+        Text(record.answer, style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(4.dp))
+        val timestamp = record.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+        Text(
+            text = "${timestamp.date} ${timestamp.time.hour}:${timestamp.time.minute.toString().padStart(2, '0')}",
+            style = MaterialTheme.typography.labelSmall
+        )
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/product/ProductListController.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/product/ProductListController.kt
@@ -1,0 +1,59 @@
+package com.sdshop.client.feature.product
+
+import com.sdshop.client.app.ProductListKey
+import com.sdshop.client.app.ProductListUiState
+import com.sdshop.client.core.event.EventBus
+import com.sdshop.client.core.event.UiEvent
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.ProductTag
+import com.sdshop.client.data.model.ThemeProduct
+import com.sdshop.client.data.repository.ThemeRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.coroutines.CoroutineContext
+
+class ProductListController(
+    private val repository: ThemeRepository,
+    private val stateStore: StateStore,
+    private val eventBus: EventBus,
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) {
+    private val scope = CoroutineScope(coroutineContext)
+    private val state = stateStore.getState(ProductListKey) { ProductListUiState() }
+
+    val uiState: StateFlow<ProductListUiState> = state.flow
+
+    fun removeProduct(productId: String) {
+        val themeId = state.flow.value.themeId ?: return
+        scope.launch {
+            repository.removeProduct(themeId, productId)
+            eventBus.publish(UiEvent.RefreshThemes)
+        }
+    }
+
+    fun addProduct(product: Product) {
+        val themeId = state.flow.value.themeId ?: return
+        scope.launch {
+            repository.addProducts(themeId, listOf(toThemeProduct(product)))
+            eventBus.publish(UiEvent.RefreshThemes)
+        }
+    }
+
+    fun openProduct(productId: String) {
+        eventBus.publish(UiEvent.LaunchSingleProduct(productId))
+    }
+
+    private fun toThemeProduct(product: Product): ThemeProduct = ThemeProduct(
+        product = product,
+        tags = buildList {
+            add(ProductTag(id = "price", label = product.price.formatted))
+            if (product.reviews != null) add(ProductTag(id = "score", label = "评分 ${product.reviews.score}"))
+        },
+        addedAtMillis = Clock.System.now().toEpochMilliseconds()
+    )
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/product/ProductScreens.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/product/ProductScreens.kt
@@ -1,0 +1,119 @@
+package com.sdshop.client.feature.product
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.sdshop.client.app.ProductListUiState
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.ProductTag
+import com.sdshop.client.data.model.ThemeProduct
+
+@Composable
+fun ProductListRoute(
+    controller: ProductListController,
+    onAddProduct: () -> Unit,
+    onOpenDetail: (Product) -> Unit
+) {
+    val state by controller.uiState.collectAsState()
+    ProductListScreen(
+        state = state,
+        onRemove = controller::removeProduct,
+        onAddProduct = onAddProduct,
+        onOpenDetail = onOpenDetail
+    )
+}
+
+@Composable
+fun ProductListScreen(
+    state: ProductListUiState,
+    onRemove: (String) -> Unit,
+    onAddProduct: () -> Unit,
+    onOpenDetail: (Product) -> Unit
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "主题商品",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Button(onClick = onAddProduct) { Text("添加商品") }
+            }
+            Spacer(Modifier.height(16.dp))
+            if (state.products.isEmpty()) {
+                Text("暂无商品，点击上方按钮添加。", style = MaterialTheme.typography.bodyMedium)
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items(state.products) { item ->
+                        ProductRow(item, onRemove = onRemove, onOpenDetail = onOpenDetail)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductRow(
+    item: ThemeProduct,
+    onRemove: (String) -> Unit,
+    onOpenDetail: (Product) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onOpenDetail(item.product) }
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(item.product.title, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(item.product.price.formatted, style = MaterialTheme.typography.titleSmall)
+            if (item.tags.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    item.tags.forEach { tag -> TagChip(tag) }
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = { onOpenDetail(item.product) }) { Text("详情") }
+                Button(onClick = { onRemove(item.product.id) }) { Text("移除") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagChip(tag: ProductTag) {
+    Text(
+        text = tag.label,
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier
+            .padding(horizontal = 4.dp, vertical = 2.dp)
+    )
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/single/SingleProductController.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/single/SingleProductController.kt
@@ -1,0 +1,86 @@
+package com.sdshop.client.feature.single
+
+import com.sdshop.client.app.SingleProductKey
+import com.sdshop.client.app.SingleProductUiState
+import com.sdshop.client.core.llm.LlmClient
+import com.sdshop.client.core.llm.LlmPrompt
+import com.sdshop.client.core.llm.LlmProvider
+import com.sdshop.client.core.llm.LlmRequest
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.data.model.InquiryRecord
+import com.sdshop.client.data.model.ToolRecord
+import com.sdshop.client.feature.tooling.ToolDefinitions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.coroutines.CoroutineContext
+import kotlin.uuid.Uuid
+
+class SingleProductController(
+    private val stateStore: StateStore,
+    private val llmClient: LlmClient,
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) {
+    private val scope = CoroutineScope(coroutineContext)
+    private val state = stateStore.getState(SingleProductKey) { SingleProductUiState() }
+
+    val uiState: StateFlow<SingleProductUiState> = state.flow
+
+    fun sendInquiry(question: String) {
+        val product = state.flow.value.product ?: return
+        if (question.isBlank()) return
+        scope.launch {
+            state.update { it.copy(isLoading = true) }
+            val prompt = LlmPrompt(
+                system = "你是商品专家，请根据单品信息回答。",
+                user = question,
+                context = mapOf(
+                    "product" to product
+                )
+            )
+            val answer = llmClient.complete(LlmRequest(provider = LlmProvider.CHAT_GPT, prompt = prompt))
+            val record = InquiryRecord(
+                id = Uuid.random().toString(),
+                question = question,
+                answer = answer,
+                timestamp = Clock.System.now(),
+                relatedProductIds = listOf(product.id)
+            )
+            state.update {
+                it.copy(
+                    isLoading = false,
+                    inquiries = it.inquiries + record
+                )
+            }
+        }
+    }
+
+    fun runTool(toolId: String) {
+        val product = state.flow.value.product ?: return
+        val tool = ToolDefinitions.defaultTools.firstOrNull { it.id == toolId } ?: return
+        scope.launch {
+            state.update { it.copy(isLoading = true) }
+            val prompt = LlmPrompt(
+                system = tool.systemPrompt,
+                user = "请针对商品《${product.title}》执行${tool.name}能力。",
+                context = mapOf("product" to product)
+            )
+            val output = llmClient.complete(LlmRequest(provider = LlmProvider.CHAT_GPT, prompt = prompt))
+            val record = ToolRecord(
+                id = Uuid.random().toString(),
+                tool = tool,
+                output = output,
+                timestamp = Clock.System.now()
+            )
+            state.update {
+                it.copy(
+                    isLoading = false,
+                    toolRecords = it.toolRecords + record
+                )
+            }
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/single/SingleProductFlowHandler.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/single/SingleProductFlowHandler.kt
@@ -1,0 +1,20 @@
+package com.sdshop.client.feature.single
+
+import com.sdshop.client.app.SingleProductKey
+import com.sdshop.client.app.SingleProductUiState
+import com.sdshop.client.core.container.FlowContext
+import com.sdshop.client.core.container.FlowHandler
+import com.sdshop.client.core.container.FlowRequest
+
+class SingleProductFlowHandler : FlowHandler<FlowRequest.SingleProductFlow> {
+    override suspend fun FlowContext.handle(request: FlowRequest.SingleProductFlow) {
+        val singleState = stateStore.getState(SingleProductKey) { SingleProductUiState() }
+        singleState.set(
+            SingleProductUiState(
+                product = request.payload.product,
+                inquiries = emptyList(),
+                toolRecords = emptyList()
+            )
+        )
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/single/SingleProductScreens.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/single/SingleProductScreens.kt
@@ -1,0 +1,136 @@
+package com.sdshop.client.feature.single
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.feature.tooling.ToolDefinitions
+
+private enum class SingleTab(val label: String) { INQUIRY("询问"), TOOLS("工具") }
+
+@Composable
+fun SingleProductRoute(
+    controller: SingleProductController,
+    onUpgrade: (Product) -> Unit
+) {
+    val state by controller.uiState.collectAsState()
+    SingleProductScreen(
+        product = state.product,
+        inquiries = state.inquiries.map { "Q: ${it.question}\n${it.answer}" },
+        toolRecords = state.toolRecords.map { "${it.tool.name}\n${it.output}" },
+        onSendInquiry = controller::sendInquiry,
+        onRunTool = controller::runTool,
+        onUpgrade = onUpgrade
+    )
+}
+
+@Composable
+fun SingleProductScreen(
+    product: Product?,
+    inquiries: List<String>,
+    toolRecords: List<String>,
+    onSendInquiry: (String) -> Unit,
+    onRunTool: (String) -> Unit,
+    onUpgrade: (Product) -> Unit
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        if (product == null) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("未找到商品", style = MaterialTheme.typography.titleMedium)
+            }
+            return@Surface
+        }
+        var selectedTab by remember { mutableStateOf(SingleTab.INQUIRY) }
+        var draft by remember { mutableStateOf("") }
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(product.title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Button(onClick = { onUpgrade(product) }) { Text("升级为主题") }
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(product.price.formatted, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(16.dp))
+            TabRow(selectedTabIndex = selectedTab.ordinal) {
+                SingleTab.values().forEachIndexed { index, tab ->
+                    Tab(selected = index == selectedTab.ordinal, onClick = { selectedTab = tab }) {
+                        Text(tab.label, modifier = Modifier.padding(12.dp))
+                    }
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            when (selectedTab) {
+                SingleTab.INQUIRY -> {
+                    Column(modifier = Modifier.weight(1f)) {
+                        inquiries.forEach { text ->
+                            Text(text, modifier = Modifier.padding(vertical = 4.dp))
+                        }
+                        Spacer(Modifier.height(12.dp))
+                        TextField(
+                            value = draft,
+                            onValueChange = { draft = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            label = { Text("提问商品问题") }
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        Button(onClick = { onSendInquiry(draft); draft = "" }, enabled = draft.isNotBlank()) {
+                            Text("发送")
+                        }
+                    }
+                }
+                SingleTab.TOOLS -> {
+                    Column(modifier = Modifier.weight(1f)) {
+                        ToolDefinitions.defaultTools.forEach { tool ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(tool.name, style = MaterialTheme.typography.titleMedium)
+                                    Text(tool.description, style = MaterialTheme.typography.bodySmall)
+                                }
+                                Button(onClick = { onRunTool(tool.id) }) { Text("执行") }
+                            }
+                        }
+                        Spacer(Modifier.height(12.dp))
+                        toolRecords.forEach { output ->
+                            Text(output, modifier = Modifier.padding(vertical = 4.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/theme/ThemeFlowHandler.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/theme/ThemeFlowHandler.kt
@@ -1,0 +1,90 @@
+package com.sdshop.client.feature.theme
+
+import com.sdshop.client.app.AppScaffoldKey
+import com.sdshop.client.app.AppScaffoldState
+import com.sdshop.client.app.AppTab
+import com.sdshop.client.app.InquiryKey
+import com.sdshop.client.app.InquiryUiState
+import com.sdshop.client.app.ProductListKey
+import com.sdshop.client.app.ProductListUiState
+import com.sdshop.client.app.ThemeListKey
+import com.sdshop.client.app.ThemeListUiState
+import com.sdshop.client.app.ToolKey
+import com.sdshop.client.app.ToolUiState
+import com.sdshop.client.core.container.FlowContext
+import com.sdshop.client.core.container.FlowHandler
+import com.sdshop.client.core.container.FlowRequest
+import com.sdshop.client.core.event.UiEvent
+import com.sdshop.client.data.model.ThemeProduct
+import com.sdshop.client.feature.tooling.ToolDefinitions
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+
+class ThemeFlowHandler : FlowHandler<FlowRequest.ThemeFlow> {
+    override suspend fun FlowContext.handle(request: FlowRequest.ThemeFlow) {
+        val themeState = stateStore.getState(ThemeListKey) { ThemeListUiState(isLoading = true) }
+        val productState = stateStore.getState(ProductListKey) { ProductListUiState() }
+        val inquiryState = stateStore.getState(InquiryKey) { InquiryUiState() }
+        val toolState = stateStore.getState(ToolKey) {
+            ToolUiState(tools = ToolDefinitions.defaultTools)
+        }
+        val scaffoldState = stateStore.getState(AppScaffoldKey) { AppScaffoldState() }
+
+        val pendingProducts = request.importedProducts
+        if (pendingProducts.isNotEmpty()) {
+            themeState.update { it.copy(pendingImport = pendingProducts) }
+        }
+
+        lifecycle.scope.launch {
+            repository.themes.collectLatest { themes ->
+                themeState.update {
+                    val selected = it.selectedThemeId ?: request.themeId ?: themes.firstOrNull()?.id
+                    it.copy(
+                        items = themes,
+                        selectedThemeId = selected,
+                        isLoading = false
+                    )
+                }
+            }
+        }
+
+        lifecycle.scope.launch {
+            eventBus.observe(UiEvent.ThemeSelected::class.java).collectLatest { event ->
+                val theme = repository.get(event.themeId) ?: return@collectLatest
+                themeState.update { it.copy(selectedThemeId = theme.id) }
+                productState.update { ProductListUiState(themeId = theme.id, products = theme.products) }
+                inquiryState.update {
+                    it.copy(themeId = theme.id, records = theme.inquiries, isLoading = false)
+                }
+                toolState.update {
+                    it.copy(themeId = theme.id, records = theme.toolRecords, tools = ToolDefinitions.defaultTools)
+                }
+                scaffoldState.update { it.copy(currentTab = AppTab.PRODUCTS) }
+            }
+        }
+
+        if (request.themeId != null) {
+            eventBus.publish(UiEvent.ThemeSelected(request.themeId))
+        }
+
+        if (pendingProducts.isNotEmpty()) {
+            // Auto create a theme to host imported products if none selected yet
+            val targetThemeId = themeState.flow.value.selectedThemeId
+            if (targetThemeId != null) {
+                val themeProducts = pendingProducts.map { product ->
+                    ThemeProduct(product = product, addedAtMillis = Clock.System.now().toEpochMilliseconds())
+                }
+                repository.addProducts(targetThemeId, themeProducts)
+                themeState.update { it.copy(pendingImport = emptyList()) }
+            }
+        }
+
+        lifecycle.scope.launch {
+            eventBus.observe(UiEvent.RefreshThemes::class.java).collectLatest {
+                val selectedId = themeState.flow.value.selectedThemeId
+                selectedId?.let { eventBus.publish(UiEvent.ThemeSelected(it)) }
+            }
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/theme/ThemeListController.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/theme/ThemeListController.kt
@@ -1,0 +1,104 @@
+package com.sdshop.client.feature.theme
+
+import com.sdshop.client.app.ThemeListKey
+import com.sdshop.client.app.ThemeListUiState
+import com.sdshop.client.core.event.EventBus
+import com.sdshop.client.core.event.UiEvent
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.data.model.Product
+import com.sdshop.client.data.model.ProductTag
+import com.sdshop.client.data.model.Theme
+import com.sdshop.client.data.model.ThemePreference
+import com.sdshop.client.data.model.ThemeProduct
+import com.sdshop.client.data.repository.ThemeRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.coroutines.CoroutineContext
+import kotlin.uuid.Uuid
+
+class ThemeListController(
+    private val repository: ThemeRepository,
+    private val stateStore: StateStore,
+    private val eventBus: EventBus,
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) {
+    private val scope = CoroutineScope(coroutineContext)
+    private val state = stateStore.getState(ThemeListKey) { ThemeListUiState(isLoading = true) }
+
+    val uiState: StateFlow<ThemeListUiState> = state.flow
+
+    init {
+        scope.launch {
+            repository.themes.collect { themes ->
+                state.update {
+                    it.copy(
+                        items = themes,
+                        isLoading = false,
+                        selectedThemeId = it.selectedThemeId ?: themes.firstOrNull()?.id
+                    )
+                }
+            }
+        }
+    }
+
+    fun selectTheme(themeId: String) {
+        eventBus.publish(UiEvent.ThemeSelected(themeId))
+    }
+
+    fun createTheme(
+        title: String,
+        preference: ThemePreference,
+        initialProducts: List<Product> = emptyList()
+    ) {
+        scope.launch {
+            val theme = Theme(
+                id = Uuid.random().toString(),
+                title = title,
+                preference = preference
+            )
+            repository.upsert(theme)
+            if (initialProducts.isNotEmpty()) {
+                repository.addProducts(
+                    theme.id,
+                    initialProducts.map { toThemeProduct(it) }
+                )
+            }
+            selectTheme(theme.id)
+        }
+    }
+
+    fun updateTheme(theme: Theme) {
+        scope.launch { repository.upsert(theme) }
+    }
+
+    fun deleteTheme(themeId: String) {
+        scope.launch {
+            repository.delete(themeId)
+            eventBus.publish(UiEvent.RefreshThemes)
+        }
+    }
+
+    fun importPendingToTheme(themeId: String) {
+        val pending = state.flow.value.pendingImport
+        if (pending.isEmpty()) return
+        scope.launch {
+            repository.addProducts(themeId, pending.map { toThemeProduct(it) })
+            state.update { it.copy(pendingImport = emptyList()) }
+            eventBus.publish(UiEvent.RefreshThemes)
+        }
+    }
+
+    private fun toThemeProduct(product: Product): ThemeProduct = ThemeProduct(
+        product = product,
+        tags = buildList {
+            add(ProductTag(id = "price", label = product.price.formatted))
+            product.shop?.let { add(ProductTag(id = "shop", label = it.name)) }
+            if (product.rankings.isNotEmpty()) add(ProductTag(id = "rank", label = product.rankings.first()))
+        },
+        addedAtMillis = Clock.System.now().toEpochMilliseconds()
+    )
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/theme/ThemeScreens.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/theme/ThemeScreens.kt
@@ -1,0 +1,195 @@
+package com.sdshop.client.feature.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.sdshop.client.app.ThemeListUiState
+import com.sdshop.client.data.model.PreferenceTag
+import com.sdshop.client.data.model.Theme
+
+@Composable
+fun ThemeListRoute(
+    controller: ThemeListController,
+    onCreateTheme: () -> Unit,
+    onEditTheme: (Theme) -> Unit,
+    onImportToTheme: (Theme) -> Unit
+) {
+    val state by controller.uiState.collectAsState()
+    ThemeListScreen(
+        state = state,
+        onSelectTheme = controller::selectTheme,
+        onCreateTheme = onCreateTheme,
+        onEditTheme = onEditTheme,
+        onImportToTheme = onImportToTheme,
+        onDeleteTheme = controller::deleteTheme
+    )
+}
+
+@Composable
+fun ThemeListScreen(
+    state: ThemeListUiState,
+    onSelectTheme: (String) -> Unit,
+    onCreateTheme: () -> Unit,
+    onEditTheme: (Theme) -> Unit,
+    onImportToTheme: (Theme) -> Unit,
+    onDeleteTheme: (String) -> Unit
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "我的主题",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Button(onClick = onCreateTheme) {
+                    Text("新增主题")
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            if (state.isEmpty) {
+                EmptyThemeHint(onCreateTheme = onCreateTheme)
+            } else {
+                if (state.pendingImport.isNotEmpty()) {
+                    ImportBanner(count = state.pendingImport.size)
+                }
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items(state.items) { theme ->
+                        ThemeRow(
+                            theme = theme,
+                            isSelected = theme.id == state.selectedThemeId,
+                            onClick = { onSelectTheme(theme.id) },
+                            onEdit = { onEditTheme(theme) },
+                            onImport = { onImportToTheme(theme) },
+                            onDelete = { onDeleteTheme(theme.id) },
+                            showImport = state.pendingImport.isNotEmpty()
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyThemeHint(onCreateTheme: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("创建你的第一个主题，用主题组织购物决策。", style = MaterialTheme.typography.bodyLarge)
+        Spacer(Modifier.height(24.dp))
+        Button(onClick = onCreateTheme) { Text("立即创建") }
+    }
+}
+
+@Composable
+private fun ImportBanner(count: Int) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f))
+            .padding(12.dp)
+    ) {
+        Text("有$count 件新商品等待加入主题，选择一个主题完成导入。", color = MaterialTheme.colorScheme.primary)
+    }
+}
+
+@Composable
+private fun ThemeRow(
+    theme: Theme,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    onEdit: () -> Unit,
+    onImport: () -> Unit,
+    onDelete: () -> Unit,
+    showImport: Boolean
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(theme.title, style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(4.dp))
+                    PreferenceTags(theme.preference.tags)
+                    if (theme.preference.freeText.isNotBlank()) {
+                        Spacer(Modifier.height(4.dp))
+                        Text(theme.preference.freeText, style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text("${theme.products.size} 件商品", style = MaterialTheme.typography.bodySmall)
+                    Text("最近更新 ${theme.updatedAt}", style = MaterialTheme.typography.labelSmall)
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onEdit) { Text("编辑") }
+                Button(onClick = onDelete) { Text("删除") }
+                if (showImport) {
+                    Button(onClick = onImport) { Text("导入") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreferenceTags(tags: List<PreferenceTag>) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (tags.isEmpty()) {
+            Text("未设置偏好", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        } else {
+            tags.forEach { tag ->
+                Box(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f))
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(tag.displayName, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/tooling/ToolController.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/tooling/ToolController.kt
@@ -1,0 +1,64 @@
+package com.sdshop.client.feature.tooling
+
+import com.sdshop.client.app.ToolKey
+import com.sdshop.client.app.ToolUiState
+import com.sdshop.client.core.llm.LlmClient
+import com.sdshop.client.core.llm.LlmPrompt
+import com.sdshop.client.core.llm.LlmProvider
+import com.sdshop.client.core.llm.LlmRequest
+import com.sdshop.client.core.state.StateStore
+import com.sdshop.client.data.model.ToolDefinition
+import com.sdshop.client.data.model.ToolRecord
+import com.sdshop.client.data.repository.ThemeRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.coroutines.CoroutineContext
+import kotlin.uuid.Uuid
+
+class ToolController(
+    private val repository: ThemeRepository,
+    private val stateStore: StateStore,
+    private val llmClient: LlmClient,
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.Default
+) {
+    private val scope = CoroutineScope(coroutineContext)
+    private val state = stateStore.getState(ToolKey) {
+        ToolUiState(tools = ToolDefinitions.defaultTools)
+    }
+
+    val uiState: StateFlow<ToolUiState> = state.flow
+
+    fun run(tool: ToolDefinition) {
+        val themeId = state.flow.value.themeId ?: return
+        scope.launch {
+            state.update { it.copy(isLoading = true) }
+            val theme = repository.get(themeId) ?: return@launch
+            val prompt = LlmPrompt(
+                system = tool.systemPrompt,
+                user = "请结合主题《${theme.title}》、偏好${theme.preference}以及${theme.products.size}件商品，执行${tool.name}能力。",
+                context = mapOf(
+                    "products" to theme.products,
+                    "tools" to tool.capabilities
+                )
+            )
+            val output = llmClient.complete(LlmRequest(provider = LlmProvider.CHAT_GPT, prompt = prompt))
+            val record = ToolRecord(
+                id = Uuid.random().toString(),
+                tool = tool,
+                output = output,
+                timestamp = Clock.System.now()
+            )
+            repository.appendToolRecord(themeId, record)
+            state.update {
+                it.copy(
+                    isLoading = false,
+                    records = it.records + record
+                )
+            }
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/tooling/ToolDefinitions.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/tooling/ToolDefinitions.kt
@@ -1,0 +1,29 @@
+package com.sdshop.client.feature.tooling
+
+import com.sdshop.client.data.model.ToolDefinition
+
+object ToolDefinitions {
+    val defaultTools = listOf(
+        ToolDefinition(
+            id = "compare",
+            name = "规格对比",
+            description = "对比主题内商品的关键参数与指标。",
+            systemPrompt = "你是一个善于分析商品规格的专家，输出对比表格。",
+            capabilities = listOf("spec_comparison", "table")
+        ),
+        ToolDefinition(
+            id = "price_trend",
+            name = "价格趋势",
+            description = "分析价格变化、满减活动和组合优惠。",
+            systemPrompt = "你擅长分析电商价格趋势，请结合优惠给出建议。",
+            capabilities = listOf("price_analysis", "promotion")
+        ),
+        ToolDefinition(
+            id = "review_guardian",
+            name = "口碑守护",
+            description = "总结评价与问大家热点。",
+            systemPrompt = "总结评价、问大家的问题，输出风险与亮点。",
+            capabilities = listOf("review_summary", "qa_cluster")
+        )
+    )
+}

--- a/client/src/commonMain/kotlin/com/sdshop/client/feature/tooling/ToolScreens.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/feature/tooling/ToolScreens.kt
@@ -1,0 +1,94 @@
+package com.sdshop.client.feature.tooling
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sdshop.client.app.ToolUiState
+import com.sdshop.client.data.model.ToolDefinition
+import com.sdshop.client.data.model.ToolRecord
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+fun ToolRoute(controller: ToolController) {
+    val state by controller.uiState.collectAsState()
+    ToolScreen(state = state, onRunTool = controller::run)
+}
+
+@Composable
+fun ToolScreen(
+    state: ToolUiState,
+    onRunTool: (ToolDefinition) -> Unit
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Text("主题工具", style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(16.dp))
+            Text("智能工具会基于当前主题和偏好，为你完成不同分析任务。", style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.height(16.dp))
+            LazyColumn(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                items(state.tools) { tool ->
+                    ToolRow(tool = tool, onRunTool = onRunTool)
+                }
+            }
+            Spacer(Modifier.height(24.dp))
+            Text("历史记录", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(12.dp))
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                items(state.records) { record ->
+                    ToolRecordRow(record)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToolRow(tool: ToolDefinition, onRunTool: (ToolDefinition) -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(tool.name, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(tool.description, style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                tool.capabilities.forEach { capability ->
+                    Text(capability, style = MaterialTheme.typography.labelSmall)
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Button(onClick = { onRunTool(tool) }) { Text("运行") }
+        }
+    }
+}
+
+@Composable
+private fun ToolRecordRow(record: ToolRecord) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(record.tool.name, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(record.output, style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.height(4.dp))
+            val timestamp = record.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+            Text("${timestamp.date} ${timestamp.time.hour}:${timestamp.time.minute.toString().padStart(2, '0')}", style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}

--- a/client/src/commonTest/kotlin/com/sdshop/client/ThemeControllerTest.kt
+++ b/client/src/commonTest/kotlin/com/sdshop/client/ThemeControllerTest.kt
@@ -1,0 +1,29 @@
+package com.sdshop.client
+
+import com.sdshop.client.core.event.SharedFlowEventBus
+import com.sdshop.client.core.state.InMemoryStateStore
+import com.sdshop.client.data.model.ThemePreference
+import com.sdshop.client.data.repository.InMemoryThemeRepository
+import com.sdshop.client.feature.theme.ThemeListController
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThemeControllerTest {
+    @Test
+    fun createThemeAddsEntry() = runTest {
+        val repository = InMemoryThemeRepository()
+        val store = InMemoryStateStore()
+        val controller = ThemeListController(repository, store, SharedFlowEventBus(), coroutineContext = coroutineContext)
+        controller.createTheme("户外装备", ThemePreference())
+        advanceUntilIdle()
+        val state = controller.uiState.value
+        assertFalse(state.isEmpty)
+        assertEquals(1, state.items.size)
+        assertEquals("户外装备", state.items.first().title)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,26 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "1.9.24"
+        id("com.android.library") version "8.2.2"
+        id("org.jetbrains.compose") version "1.6.11"
+        id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24"
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "sdshop"
+include(":client")


### PR DESCRIPTION
## Summary
- introduce a Kotlin Multiplatform + Compose client module with shared business container, event bus, state store, and LLM gateway abstractions
- add theme, product, inquiry, tool, and single-product flows with controllers, view models, and Compose screens tied into the new business container
- provide a product detail surface and update the README to document the client module entry point

## Testing
- `gradle -q --console=plain :client:check` *(fails: Gradle plugin org.jetbrains.kotlin.multiplatform:1.9.24 unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce94f9ba78832aa0c60690ec7966aa