### PR TITLE
Add iOS Compose entry point and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,46 @@
 客户端实现将基于 `docs/architecture.md` 描述的业务容器、状态管理与导航方案。
 `client/` 目录提供 Kotlin Multiplatform + Compose 的跨端实现，包含业务容器、状态管理、主题/商品/询问/工具/单品等 Tab 视图以及事件网关、LLM 调用的抽象封装。
 
+## iOS 客户端运行
+
+> ⚠️ 由于 iOS 构建依赖 Xcode 工具链，请在安装了 Xcode 的 macOS 环境中执行以下步骤。
+
+1. 在项目根目录执行：
+
+   ```bash
+   ./gradlew :client:linkDebugFrameworkIosSimulatorArm64
+   ```
+
+   生成的 Compose 静态框架位于 `client/build/bin/iosSimulatorArm64/debugStatic/SdShopClient.framework`。
+
+2. 使用 Xcode 创建一个 `App` 工程，并在 *General → Frameworks, Libraries, and Embedded Content* 中添加上一步生成的 `SdShopClient.framework`（模拟器调试请保持 `Do Not Embed`）。
+
+3. 在 SwiftUI/Swift 入口中引入 Kotlin 侧提供的 `MainViewController()`：
+
+   ```swift
+   import SwiftUI
+   import SdShopClient
+
+   struct ComposeRootView: UIViewControllerRepresentable {
+       func makeUIViewController(context: Context) -> UIViewController {
+           SdShopClientMainViewControllerKt.MainViewController()
+       }
+
+       func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+   }
+
+   @main
+   struct IOSApp: App {
+       var body: some Scene {
+           WindowGroup {
+               ComposeRootView()
+           }
+       }
+   }
+   ```
+
+   运行后即可看到与 Android 端一致的业务容器与界面。
+
 ## 开发环境
 
 1. 创建虚拟环境并安装依赖：

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     kotlin("multiplatform")
@@ -12,6 +13,13 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+
+    targets.withType<KotlinNativeTarget> {
+        binaries.framework {
+            baseName = "SdShopClient"
+            isStatic = true
+        }
+    }
 
     sourceSets {
         val coroutinesVersion = "1.8.1"

--- a/client/src/commonMain/kotlin/com/sdshop/client/app/AppEntry.kt
+++ b/client/src/commonMain/kotlin/com/sdshop/client/app/AppEntry.kt
@@ -1,0 +1,10 @@
+package com.sdshop.client.app
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+@Composable
+fun SdShopApp(environmentFactory: () -> AppEnvironment = { AppEnvironmentFactory.create() }) {
+    val environment = remember(environmentFactory) { environmentFactory() }
+    AppRoot(environment)
+}

--- a/client/src/iosMain/kotlin/com/sdshop/client/app/MainViewController.kt
+++ b/client/src/iosMain/kotlin/com/sdshop/client/app/MainViewController.kt
@@ -1,0 +1,10 @@
+package com.sdshop.client.app
+
+import androidx.compose.ui.window.ComposeUIViewController
+import platform.UIKit.UIViewController
+
+fun MainViewController(
+    environmentFactory: () -> AppEnvironment = { AppEnvironmentFactory.create() }
+): UIViewController = ComposeUIViewController {
+    SdShopApp(environmentFactory)
+}


### PR DESCRIPTION
## Summary
- add a reusable `SdShopApp` composable that wires the shared environment
- expose an iOS `MainViewController` backed by Compose for shared UI reuse
- configure the KMP module to produce a static iOS framework and document build steps for running the iOS app

## Testing
- gradle :client:compileKotlinIosSimulatorArm64 --console=plain *(fails: plugin org.jetbrains.kotlin.multiplatform:1.9.24 could not be resolved in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9f6ef2b4832abb3c55f3126c8014